### PR TITLE
v0.2.6: Support another way of delaying execution

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@danopia/http-file",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "imports": {
     "@cloudydeno/opentelemetry": "jsr:@cloudydeno/opentelemetry@~0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@cloudydeno/opentelemetry@0.11": "0.11.0",
     "jsr:@std/assert@1": "1.0.14",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@1": "1.0.22",
     "jsr:@std/internal@^1.0.10": "1.0.10",
     "jsr:@std/streams@1": "1.0.12"
@@ -17,6 +18,9 @@
         "jsr:@std/internal"
       ]
     },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
     "@std/cli@1.0.22": {
       "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
     },
@@ -24,7 +28,10 @@
       "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
     },
     "@std/streams@1.0.12": {
-      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4"
+      "integrity": "ae925fa1dc459b1abf5cbaa28cc5c7b0485853af3b2a384b0dc22d86e59dfbf4",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
     }
   },
   "workspace": {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -122,5 +122,8 @@ function transformScript(text: string) {
   text = text.replace(/import {wait} from "[^"]+"\n/, '');
   text = text.replace(/^( +)(wait\()/m, (_,a,b) => `${a}await ${b}`);
 
+  // Another way of delaying execution:
+  text = text.replace(/^( +)execSync\('sleep ([0-9]+)'\)/m, (_,a,b) => `${a}await wait(${b})`);
+
   return text;
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S deno run --allow-read=. --allow-write=.
 import { parseHttpSyntax } from "./parser.ts";
+import { transformScript } from "./transformer.ts";
 import type { HttpBlock } from "./types.ts";
 
 if (import.meta.main) {
@@ -112,18 +113,4 @@ export async function* renderHttpScript(
     `  await script.runNow();`,
     `}`,
   ].join('\n')+'\n';
-}
-
-function transformScript(text: string) {
-
-  // The http file community has a 'wait' workaround for the lack of a delay function
-  // We try to replace several versions of that with a proper async sleep
-  text = text.replace(/const wait = seconds => \{[^}]+\};\n/, '');
-  text = text.replace(/import {wait} from "[^"]+"\n/, '');
-  text = text.replace(/^( +)(wait\()/m, (_,a,b) => `${a}await ${b}`);
-
-  // Another way of delaying execution:
-  text = text.replace(/^( +)execSync\('sleep ([0-9]+)'\)/m, (_,a,b) => `${a}await wait(${b})`);
-
-  return text;
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -92,5 +92,8 @@ function transformScript(text: string) {
   text = text.replace(/import {wait} from "[^"]+"\n/, '');
   text = text.replace(/^( +)(wait\()/m, (_,a,b) => `${a}await ${b}`);
 
+  // Another way of delaying execution:
+  text = text.replace(/^( +)execSync\('sleep ([0-9]+)'\)/m, (_,a,b) => `${a}await wait(${b})`);
+
   return text;
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -2,6 +2,7 @@
 import { parseArgs } from "@std/cli/parse-args";
 
 import { parseHttpSyntax } from "./parser.ts";
+import { transformScript } from "./transformer.ts";
 import { HttpScript } from "./runtime.ts";
 import type { HttpBlock, PluginRegistration } from "./types.ts";
 
@@ -82,18 +83,4 @@ export async function instantiateHttpScript(
   }
 
   return script;
-}
-
-function transformScript(text: string) {
-
-  // The http file community has a 'wait' workaround for the lack of a delay function
-  // We try to replace several versions of that with a proper async sleep
-  text = text.replace(/const wait = seconds => \{[^}]+\};\n/, '');
-  text = text.replace(/import {wait} from "[^"]+"\n/, '');
-  text = text.replace(/^( +)(wait\()/m, (_,a,b) => `${a}await ${b}`);
-
-  // Another way of delaying execution:
-  text = text.replace(/^( +)execSync\('sleep ([0-9]+)'\)/m, (_,a,b) => `${a}await wait(${b})`);
-
-  return text;
 }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,0 +1,13 @@
+export function transformScript(text: string) {
+
+  // The http file community has a 'wait' workaround for the lack of a delay function
+  // We try to replace several versions of that with a proper async sleep
+  text = text.replace(/const wait = seconds => \{[^}]+\};\n/, '');
+  text = text.replace(/import {wait} from "[^"]+"\n/, '');
+  text = text.replace(/^( +)(wait\()/m, (_,a,b) => `${a}await ${b}`);
+
+  // Another way of delaying execution:
+  text = text.replace(/^( +)execSync\('sleep ([0-9]+)'\)/m, (_,a,b) => `${a}await wait(${b})`);
+
+  return text;
+}


### PR DESCRIPTION
Support post scripts with this sort of delay hack:

```ts
> {%
    execSync('sleep 2')

    client.test("Request executed successfully", function () {
        client.assert(response.status === 204, "Response status is not 204");
    });
%}
```

It is now mapped into an await statement, same as with the previous loop-based hack:

```ts
  async postScript(client: Client, request, response) {
    await wait(2)

    client.test("Request executed successfully", function () {
        client.assert(response.status === 204, "Response status is not 204");
    });
  },
```